### PR TITLE
Async await

### DIFF
--- a/text/0000-async_await.md
+++ b/text/0000-async_await.md
@@ -571,14 +571,14 @@ There are a couple of possible solutions:
 This is left as an unresolved question to find another solution or decide which
 of these is least bad.
 
-## `async for` and processing streams
+## `for await` and processing streams
 
 Another extension left out of the RFC for now is the ability to process streams
-using a for loop. One could imagine a construct like `async for`, which takes
+using a for loop. One could imagine a construct like `for await`, which takes
 an `IntoStream` instead of an `IntoIterator`:
 
 ```rust
-async for value in stream {
+for await value in stream {
     println!("{}", value);
 }
 ```

--- a/text/0000-async_await.md
+++ b/text/0000-async_await.md
@@ -119,6 +119,9 @@ fn main() {
 This will print both "Hello from main" statements before printing "Hello from
 async closure."
 
+`async` closures can be annotated with `move` to capture ownership of the
+variables they close over.
+
 ## `async` blocks
 
 You can create a future directly as an expression using an `async` block:
@@ -240,7 +243,7 @@ fn foo<'a>(arg1: &'a str, arg2: &str) -> impl Future<Output = usize> + 'a {
     // do some initialization using arg2
 
     // closure which is evaluated immediately
-    move async {
+    async move {
          // asynchronous portion of the function
     }
 }
@@ -264,6 +267,19 @@ loop {
 This is not a literal expansion, because the `yield` concept cannot be
 expressed in the surface syntax within `async` functions. This is why `await!`
 is a compiler builtin instead of an actual macro.
+
+## The order of `async` and `move`
+
+Async closures and blocks can be annotated with `move` to capture ownership of
+the variables they close over. The order of the keywords is fixed to
+`async move`. Permitting only one ordering avoids confusion about whether it is
+significant for the meaning.
+
+```rust
+async move {
+    // body
+}
+```
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/0000-async_await.md
+++ b/text/0000-async_await.md
@@ -25,7 +25,7 @@ The development of asynchronous IO in Rust has gone through multiple phases.
 Prior to 1.0, we experimented with having a green-threading runtime built into
 the language. However, this proved too opinionated - because it impacted every
 program written in Rust - and it was removed shortly before 1.0. After 1.0,
-asynchronous IO initially focused around the mio library, which provided an
+asynchronous IO initially focused around the mio library, which provided a
 cross-platform abstraction over the async IO primitives of Linux, Mac OS, and
 Windows. In mid-2016, the introduction of the futures crate had a major impact
 by providing a convenient, shared abstraction for asynchronous operations. The
@@ -164,7 +164,7 @@ yielding control of the function when it returns `Poll::Pending` and
 eventually evaluating to the item value when it returns `Poll::Ready`.
 
 `await!` can only be used inside of an async function, closure, or block.
-Using outside of that context is an error.
+Using it outside of that context is an error.
 
 (`await!` is a compiler built-in to leave space for deciding its exact syntax
 later. See more information in the unresolved questions section.)
@@ -193,8 +193,8 @@ state, which contains all of the arguments to this function.
 The anonymous return type implements `Future`, with the return type as its
 `Item`. Polling it advances the state of the function, returning `Pending`
 when it hits an `await` point, and `Ready` with the item when it hits a
-`return` point. Any attempt to poll it after it has already returned Ready once
-will panic.
+`return` point. Any attempt to poll it after it has already returned `Ready`
+once will panic.
 
 The anonymous return type has a negative impl for the `Unpin` trait - that is
 `impl !Unpin`. This is because the future could have internal references which

--- a/text/0000-async_await.md
+++ b/text/0000-async_await.md
@@ -224,10 +224,10 @@ Future<Output = T>`.
 ### "Initialization" pattern
 
 One pattern that sometimes occurs is that a future has an "initialization" step
-which could ideally happen before the future starts being polled. Because the
-async function does not begin evaluating until you poll it, and it captures the
-lifetimes of its arguments, this pattern cannot be expressed with a single
-`async fn`.
+which should be performed during its construction. This is useful when dealing
+with data conversion and temporary borrows. Because the async function does not
+begin evaluating until you poll it, and it captures the lifetimes of its
+arguments, this pattern cannot be expressed directly with an `async fn`.
 
 One option is to write a function that returns `impl Future` using a closure
 which is evaluated immediately:


### PR DESCRIPTION
@aturon This fixes all the points I mentioned in the issue.

- Fixes some typos
- Clarifies usefulness of the initialization pattern
- Makes `?`-operator and control-flow constructs in async blocks an unresolved question
- Fixes the keyword ordering of `async move`
- Renames `async for` to `for await` (like in JavaScript)